### PR TITLE
refactor: `Order Reading Converter`가 `ZonedDateTime`과 `LocalDateTime`을 모두 지원하도록 수정

### DIFF
--- a/src/main/kotlin/org/rooftop/order/domain/repository/OrderConverter.kt
+++ b/src/main/kotlin/org/rooftop/order/domain/repository/OrderConverter.kt
@@ -8,8 +8,11 @@ import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.data.convert.WritingConverter
 import org.springframework.data.r2dbc.mapping.OutboundRow
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
 
 class OrderConverter {
 
@@ -31,11 +34,17 @@ class OrderConverter {
                 ),
                 state = OrderState.valueOf(source["state"] as String),
                 version = source["version"] as Int,
-                createdAt = (source["created_at"] as LocalDateTime).atZone(ZoneId.systemDefault())
-                    .toInstant(),
-                modifiedAt = (source["modified_at"] as LocalDateTime).atZone(ZoneId.systemDefault())
-                    .toInstant(),
+                createdAt = toInstant(source["created_at"] as Temporal),
+                modifiedAt = toInstant(source["modified_at"] as Temporal),
             )
+        }
+
+        private fun toInstant(temporal: Temporal): Instant {
+            return when (temporal) {
+                is LocalDateTime -> temporal.atZone(ZoneId.systemDefault()).toInstant()
+                is ZonedDateTime -> temporal.toInstant()
+                else -> error("Not supported temporal type \"${temporal::class.simpleName}\"")
+            }
         }
     }
 }

--- a/src/test/kotlin/org/rooftop/order/domain/OrderRepositoryTest.kt
+++ b/src/test/kotlin/org/rooftop/order/domain/OrderRepositoryTest.kt
@@ -36,6 +36,4 @@ internal class OrderRepositoryTest(private val orderRepository: OrderRepository)
             }
         }
     }
-}) {
-
-}
+})


### PR DESCRIPTION
- close #26 